### PR TITLE
Fix #77 sync command not working on android devices 

### DIFF
--- a/src/services/NsCliService.ts
+++ b/src/services/NsCliService.ts
@@ -251,7 +251,7 @@ export class AndroidProject extends NSProject {
                     that.emit('TNS.outputMessage', data.toString(), 'log');
                     that.writeToTnsOutputFile(strData);
                     if (!launched) {
-                         if (args.request === "launch" && ((strData.indexOf('# NativeScript Debugger started #') > -1) || strData.indexOf('Successfully synced application') > -1)) {
+                         if (args.request === "launch" && strData.indexOf('# NativeScript Debugger started #') > -1) {
                              launched = true;
                              //wait a little before trying to connect, this gives a changes for adb to be able to connect to the debug socket
                              setTimeout(() => {


### PR DESCRIPTION
Fix debugger not attaching and hanging the android process when attempting to connect too early to device, before the application has started.

@ivanbuhov 