### PR TITLE
[iOS] Support for breakpoints with ignoreCount in iOS only

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "publisher": "Telerik",
   "bugs": "https://github.com/NativeScript/nativescript-vscode-extension/issues",
   "engines": {
-    "vscode": "^1.5.0"
+    "vscode": "^1.7.0"
   },
   "homepage": "https://www.nativescript.org/",
   "categories": [
@@ -29,8 +29,8 @@
     "source-map": "^0.5.3",
     "xmlhttprequest": "https://github.com/telerik/node-XMLHttpRequest/tarball/master",
     "universal-analytics": "^0.4.6",
-    "vscode-debugadapter": "^1.7.0",
-    "vscode-debugprotocol": "^1.7.0"
+    "vscode-debugadapter": "^1.14.0",
+    "vscode-debugprotocol": "^1.14.0"
   },
   "devDependencies": {
     "@types/es6-collections": "^0.5.29",

--- a/src/debug-adapter/connection/INSDebugConnection.ts
+++ b/src/debug-adapter/connection/INSDebugConnection.ts
@@ -3,7 +3,7 @@ export interface INSDebugConnection {
 
     close(): void;
 
-    debugger_setBreakpointByUrl(url: string, lineNumber: number, columnNumber: number, condition?: string): Promise<WebKitProtocol.Debugger.SetBreakpointByUrlResponse>
+    debugger_setBreakpointByUrl(url: string, lineNumber: number, columnNumber: number, condition: string, ignoreCount: number): Promise<WebKitProtocol.Debugger.SetBreakpointByUrlResponse>
 
     debugger_removeBreakpoint(breakpointId: string): Promise<WebKitProtocol.Response>
 

--- a/src/debug-adapter/connection/androidConnection.ts
+++ b/src/debug-adapter/connection/androidConnection.ts
@@ -450,17 +450,15 @@ export class AndroidConnection implements INSDebugConnection {
         this._socket.close();
     }
 
-    public debugger_setBreakpointByUrl(url: string, lineNumber: number, columnNumber: number, condition?: string): Promise<WebKitProtocol.Debugger.SetBreakpointByUrlResponse> {
-        //throw new Error("Not implemented");
-        //return this.sendMessage('Debugger.setBreakpointByUrl', <WebKitProtocol.Debugger.SetBreakpointByUrlParams>{ url, lineNumber, columnNumber });
-
+    public debugger_setBreakpointByUrl(url: string, lineNumber: number, columnNumber: number, condition: string, ignoreCount: number): Promise<WebKitProtocol.Debugger.SetBreakpointByUrlResponse> {
         let that = this;
         var requestParams = {
             type: 'script',
             target: that.inspectorUrlToV8Name(url),
             line: lineNumber,
             column: columnNumber,
-            condition: condition
+            condition: condition,
+            ignoreCount: ignoreCount
         };
 
         return this.request("setbreakpoint", requestParams)

--- a/src/debug-adapter/connection/iosConnection.ts
+++ b/src/debug-adapter/connection/iosConnection.ts
@@ -178,8 +178,8 @@ export class IosConnection implements INSDebugConnection {
         return this.sendMessage('Debugger.setBreakpoint', <WebKitProtocol.Debugger.SetBreakpointParams>{ location, options: { condition: condition }});
     }
 
-    public debugger_setBreakpointByUrl(url: string, lineNumber: number, columnNumber: number, condition?: string): Promise<WebKitProtocol.Debugger.SetBreakpointByUrlResponse> {
-        return this.sendMessage('Debugger.setBreakpointByUrl', <WebKitProtocol.Debugger.SetBreakpointByUrlParams>{ url: url, lineNumber: lineNumber, columnNumber: 0 /* a columnNumber different from 0 confuses the debugger */, options: { condition: condition }});
+    public debugger_setBreakpointByUrl(url: string, lineNumber: number, columnNumber: number, condition: string, ignoreCount: number): Promise<WebKitProtocol.Debugger.SetBreakpointByUrlResponse> {
+        return this.sendMessage('Debugger.setBreakpointByUrl', <WebKitProtocol.Debugger.SetBreakpointByUrlParams>{ url: url, lineNumber: lineNumber, columnNumber: 0 /* a columnNumber different from 0 confuses the debugger */, options: { condition: condition, ignoreCount: ignoreCount }});
     }
 
     public debugger_removeBreakpoint(breakpointId: string): Promise<WebKitProtocol.Response> {

--- a/src/debug-adapter/webKitDebugAdapter.ts
+++ b/src/debug-adapter/webKitDebugAdapter.ts
@@ -83,6 +83,7 @@ export class WebKitDebugAdapter implements DebugProtocol.IDebugAdapter {
             supportsFunctionBreakpoints: false,
             supportsConditionalBreakpoints: true,
             supportsEvaluateForHovers: false,
+            supportsHitConditionalBreakpoints: true, // TODO: Not working on Android
             exceptionBreakpointFilters: [{
 				label: 'All Exceptions',
 				filter: 'all',
@@ -92,7 +93,16 @@ export class WebKitDebugAdapter implements DebugProtocol.IDebugAdapter {
 				label: 'Uncaught Exceptions',
 				filter: 'uncaught',
 				default: true
-			}]
+			}],
+            supportsStepBack: false,
+            supportsSetVariable: false, // TODO: Check if can be enabled
+            supportsRestartFrame: false, // TODO: Check if can be enabled
+            supportsGotoTargetsRequest: false, // TODO: Check if can be enabled
+            supportsStepInTargetsRequest: false, // TODO: Check if can be enabled
+            supportsCompletionsRequest: false, // TODO: Check if can be enabled
+            supportsModulesRequest: false, // TODO: Check if can be enabled
+            additionalModuleColumns: undefined, // TODO: Check if can be enabled
+            supportedChecksumAlgorithms: undefined // TODO: Check if can be enabled
         }
     }
 
@@ -377,7 +387,7 @@ export class WebKitDebugAdapter implements DebugProtocol.IDebugAdapter {
     private _addBreakpoints(url: string, breakpoints: DebugProtocol.ISetBreakpointsArgs): Promise<WebKitProtocol.Debugger.SetBreakpointByUrlResponse[]> {
         // Call setBreakpoint for all breakpoints in the script simultaneously
         const responsePs = breakpoints.breakpoints
-            .map((b, i) => this._webKitConnection.debugger_setBreakpointByUrl(url, breakpoints.lines[i], breakpoints.cols ? breakpoints.cols[i] : 0, b.condition));
+            .map((b, i) => this._webKitConnection.debugger_setBreakpointByUrl(url, breakpoints.lines[i], breakpoints.cols ? breakpoints.cols[i] : 0, b.condition, parseInt(b.hitCondition) || 0));
 
         // Join all setBreakpoint requests to a single promise
         return Promise.all(responsePs);


### PR DESCRIPTION
Fixes: https://github.com/NativeScript/nativescript-vscode-extension/issues/90

This implementation works properly only on iOS. 
On the Android side we are translating the hit count to the semantically equivalent [`ignoreCount`](https://github.com/NativeScript/nativescript-vscode-extension/compare/buhov/hit-count-support?expand=1#diff-2dc41c475bbe3598bb11d3ad87e235c9R461) property as described in the [V8 debugging protocol spec](https://github.com/v8/v8/wiki/Debugging-Protocol#request-setbreakpoint) but still after setting a breakpoint with a hit count set to some positive number, the value of `ignoreCount` is ignored and the breakpoint is hit every single time. ping @blagoev 