### PR TITLE
When the TNS process is finished - terminate the debugger process, too.

### DIFF
--- a/src/debug-adapter/webKitDebugAdapter.ts
+++ b/src/debug-adapter/webKitDebugAdapter.ts
@@ -159,7 +159,12 @@ export class WebKitDebugAdapter implements DebugProtocol.IDebugAdapter {
                 cliCommand.tnsProcess.stderr.on('data', data => { Services.logger().error(data.toString(), Tags.FrontendMessage); });
                 cliCommand.tnsProcess.on('close', (code, signal) => {
                     Services.logger().error(`[NSDebugAdapter] The tns command finished its execution with code ${code}.`, Tags.FrontendMessage);
-                    this.fireEvent(new TerminatedEvent());
+
+                    // Sometimes we execute "tns debug android --start" and the process finishes
+                    // which is totally fine. If there's an error we need to Terminate the session.
+                    if(code > 0) {
+                        this.fireEvent(new TerminatedEvent());
+                    }
                 });
             }
 

--- a/src/debug-adapter/webKitDebugAdapter.ts
+++ b/src/debug-adapter/webKitDebugAdapter.ts
@@ -1,7 +1,6 @@
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
-
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -160,6 +159,7 @@ export class WebKitDebugAdapter implements DebugProtocol.IDebugAdapter {
                 cliCommand.tnsProcess.stderr.on('data', data => { Services.logger().error(data.toString(), Tags.FrontendMessage); });
                 cliCommand.tnsProcess.on('close', (code, signal) => {
                     Services.logger().error(`[NSDebugAdapter] The tns command finished its execution with code ${code}.`, Tags.FrontendMessage);
+                    this.fireEvent(new TerminatedEvent());
                 });
             }
 


### PR DESCRIPTION
When the TNS process has been closed we're still hanging the debugger as if you can still do something. 

This is easily reproducible if there is need for interactive input from the user. For example if you have two provisioning profiles and run `launch ios` from the app it will try to find a provisioning profile for you, get confused, can't get a decision and return an error for you to pass the `teamId` as an arg. After that the TNS exits. Currently we hang, now we raise the terminate event.

Another way to test:

- Run IOS in Simulator
- Close the Simulator. The process should be terminated.