### PR TITLE
Yosifov/add teams selector

### DIFF
--- a/src/ipc/extensionClient.ts
+++ b/src/ipc/extensionClient.ts
@@ -59,4 +59,8 @@ export class ExtensionClient {
     public runRunCommand(args: extProtocol.AnalyticsRunRunCommandArgs): Promise<any> {
         return this.callRemoteMethod('runRunCommand', args);
     }
+
+    public selectTeam(): Promise<{ id: string, name: string }> {
+        return this.callRemoteMethod('selectTeam');
+    }
 }

--- a/src/ipc/extensionServer.ts
+++ b/src/ipc/extensionServer.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as os from 'os';
+import * as fs from 'fs';
 import * as crypto from 'crypto';
 import * as vscode from 'vscode';
 import * as extProtocol from './extensionProtocol';
@@ -68,4 +69,63 @@ export class ExtensionServer {
     public runRunCommand(args: extProtocol.AnalyticsRunRunCommandArgs): Promise<any> {
         return Services.analyticsService().runRunCommand(args.platform);
     }
+
+    public selectTeam() : Promise<{ id: string, name: string }> {
+        return new Promise((resolve, reject) => {
+            let developmentTeams = this.getDevelopmentTeams();
+            if(developmentTeams.length > 1) {
+                let quickPickItems = developmentTeams.map((team) => {
+                    return {
+                        label: team.name,
+                        description: team.id
+                    };
+                });
+                vscode.window.showQuickPick(quickPickItems)
+                    .then(val => resolve({
+                            id: val.description,
+                            label: val.label
+                        }));
+            } else {
+                resolve();
+            }
+        });
+    }
+
+    private getDevelopmentTeams(): Array<{ id: string, name: string }> {
+		let dir = path.join(process.env.HOME, "Library/MobileDevice/Provisioning Profiles/");
+		let files = fs.readdirSync(dir);
+		let teamIds: any = {};
+		for (let file of files) {
+			let filePath = path.join(dir, file);
+			let data = fs.readFileSync(filePath, { encoding: "utf8" });
+			let teamId = this.getProvisioningProfileValue("TeamIdentifier", data);
+			let teamName = this.getProvisioningProfileValue("TeamName", data);
+			if (teamId) {
+				teamIds[teamId] = teamName;
+			}
+		}
+
+		let teamIdsArray = new Array<{ id: string, name: string }>();
+		for (let teamId in teamIds) {
+			teamIdsArray.push({ id: teamId, name: teamIds[teamId] });
+		}
+
+		return teamIdsArray;
+	}
+
+    private getProvisioningProfileValue(name: string, text: string): string {
+		let findStr = "<key>" + name + "</key>";
+		let index = text.indexOf(findStr);
+		if (index > 0) {
+			index = text.indexOf("<string>", index + findStr.length);
+			if (index > 0) {
+				index += "<string>".length;
+				let endIndex = text.indexOf("</string>", index);
+				let result = text.substring(index, endIndex);
+				return result;
+			}
+		}
+
+		return null;
+	}
 }


### PR DESCRIPTION
When launching on iOS device we need to have the TeamId selected, otherwise the CLI will suggest the user the Teams. Unfortunately, currently the console is not Interactive and the CLI cannot get the user's input. Therefore, we're adding a Quick Pick from the Visual Studio code for the user if he has more than 1 Team from which to select. Then this is passed as "--teamId" option to the `run` command. This is not persisted anywhere, therefore the user will be asked every time.