### PR TITLE
Handle all exceptions when searching for Teams and ignore them

### DIFF
--- a/src/ipc/extensionServer.ts
+++ b/src/ipc/extensionServer.ts
@@ -92,25 +92,30 @@ export class ExtensionServer {
     }
 
     private getDevelopmentTeams(): Array<{ id: string, name: string }> {
-		let dir = path.join(process.env.HOME, "Library/MobileDevice/Provisioning Profiles/");
-		let files = fs.readdirSync(dir);
-		let teamIds: any = {};
-		for (let file of files) {
-			let filePath = path.join(dir, file);
-			let data = fs.readFileSync(filePath, { encoding: "utf8" });
-			let teamId = this.getProvisioningProfileValue("TeamIdentifier", data);
-			let teamName = this.getProvisioningProfileValue("TeamName", data);
-			if (teamId) {
-				teamIds[teamId] = teamName;
-			}
-		}
+        try {
+            let dir = path.join(process.env.HOME, "Library/MobileDevice/Provisioning Profiles/");
+            let files = fs.readdirSync(dir);
+            let teamIds: any = {};
+            for (let file of files) {
+                let filePath = path.join(dir, file);
+                let data = fs.readFileSync(filePath, { encoding: "utf8" });
+                let teamId = this.getProvisioningProfileValue("TeamIdentifier", data);
+                let teamName = this.getProvisioningProfileValue("TeamName", data);
+                if (teamId) {
+                    teamIds[teamId] = teamName;
+                }
+            }
 
-		let teamIdsArray = new Array<{ id: string, name: string }>();
-		for (let teamId in teamIds) {
-			teamIdsArray.push({ id: teamId, name: teamIds[teamId] });
-		}
+            let teamIdsArray = new Array<{ id: string, name: string }>();
+            for (let teamId in teamIds) {
+                teamIdsArray.push({ id: teamId, name: teamIds[teamId] });
+            }
 
-		return teamIdsArray;
+            return teamIdsArray;
+        } catch (e) {
+            // no matter what happens, don't break
+            return new Array<{ id: string, name: string }>();
+        }
 	}
 
     private getProvisioningProfileValue(name: string, text: string): string {


### PR DESCRIPTION
When the User doesn't have any Provisioning Profiles the directory's files cannot be listed and therefore an ENOENT exceptions was thrown. This caused the promise to hang forever and the processes hangs. Now we catch all exceptions when trying to read all Provisioning Profile's teams and return empty teams array if something goes wrong.