### PR TITLE
Pin node modules & save the iOS Team ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,25 +26,25 @@
   "license": "SEE LICENSE IN LICENSE.txt",
   "dependencies": {
     "vscode-chrome-debug-core": "3.9.1",
-    "node-ipc": "^8.9.2",
-    "source-map": "^0.5.3",
+    "node-ipc": "8.10.3",
+    "source-map": "0.5.6",
     "xmlhttprequest": "https://github.com/telerik/node-XMLHttpRequest/tarball/master",
-    "universal-analytics": "^0.4.6",
-    "vscode-debugadapter": "^1.14.0",
-    "vscode-debugprotocol": "^1.14.0"
+    "universal-analytics": "0.4.13",
+    "vscode-debugadapter": "1.19.0",
+    "vscode-debugprotocol": "1.19.0"
   },
   "devDependencies": {
-    "@types/es6-collections": "^0.5.29",
-    "@types/es6-promise": "^0.0.32",
-    "@types/mocha": "^2.2.32",
-    "@types/node": "^6.0.46",
-    "@types/source-map": "^0.1.29",
+    "@types/es6-collections": "0.5.30",
+    "@types/es6-promise": "0.0.32",
+    "@types/mocha": "2.2.41",
+    "@types/node": "6.0.46",
+    "@types/source-map": "~0.1.0",
     "chrome-remote-debug-protocol": "git://github.com/roblourens/chrome-remote-debug-protocol.git",
-    "mocha": "^2.4.5",
-    "typescript": "^2.4.0",
-    "vsce": "^1.18.0",
-    "vscode": "^1.0.3",
-    "vscode-debugadapter-testsupport": "^1.7.0"
+    "mocha": "2.5.3",
+    "typescript": "~2.4.0",
+    "vsce": "1.22.0",
+    "vscode": "1.1.0",
+    "vscode-debugadapter-testsupport": "1.19.0"
   },
   "scripts": {
     "clean": "git clean -fdx",
@@ -75,6 +75,10 @@
           "type": "string",
           "default": "tns",
           "description": "Path to the NativeScript CLI executable."
+        },
+        "nativescript.iosTeamId": {
+          "type": "string",
+          "description": "The iOS development Team ID."
         }
       }
     },

--- a/src/debug-adapter/webKitDebugAdapter.ts
+++ b/src/debug-adapter/webKitDebugAdapter.ts
@@ -158,6 +158,7 @@ export class WebKitDebugAdapter implements DebugProtocol.IDebugAdapter {
                         if(selectedTeam) {
                             // add the selected by the user Team Id
                             tnsArgs = (tnsArgs || []).concat(['--teamId', selectedTeam.id]);
+                            Services.logger().log(`[NSDebugAdapter] Using iOS Team ID '${selectedTeam.id}', you can change this in the workspace settings.\n`, Tags.FrontendMessage);
                         }
                     }
                 }


### PR DESCRIPTION
This PR does 2 things:

1. Pin the node modules to versions that actually work. The reason? I cloned the repo and built the package (worked) then installed the plugin in VSCode (worked), then launched on iOS (fail, without an error message *anywhere*). With help of `npm view <package name> versions time --json` I figured out what would have been the version of all (dev) dependencies in `package.json` at the time of the last release, and those worked just fine. So I decided to pin to those exact versions (and two of them with the `~` prefix as that doesn't do harm in those cases.
2. Save the selected iOS team id to a workspace setting. Closes #138. The team id is saved in the workspace settings which can be removed by the user if he wants to switch to a different team. But I'm not sure anyone ever wants that within the same workspace, so no need for #137 which issue #138 suggests.

Oh, as a bonus the Team ID picker's placeholder now reads "Select your development team" (it used to be empty).

[Here's a short video showing off the changes to the iOS Team ID picker](https://www.youtube.com/watch?v=lR5uyjYW0mE).

> UPDATE: I've found the node modules that caused the crashes. The `vscode-debug*` 1.24.0 versions were fine, but there was an incompatibility with 1.25.0 and up (probably because their compile targets changed to es6). By upgrading this extension to es6 as well, the issue is fixed so we can upgrade to the latest versions of those packages.. but that will be done in a follow-up PR, along with a TypeScript bump to 2.6.x.