### PR TITLE
Fixing typescript breakpoints on windows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,8 @@
             "args": [ "--server=4712" ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outDir": "${workspaceRoot}/out",
-            "cwd": "${workspaceRoot}"
+            "outFiles": [ "${workspaceFolder}/out/**/*.js" ],
+            "cwd": "${workspaceFolder}"
         },
         {
             "name": "launch in extension host",
@@ -22,10 +22,9 @@
             "args": [
                 "--extensionDevelopmentPath=${workspaceRoot}"
             ],
-            "stopOnEntry": true,
-			"sourceMaps": true,
-            "outDir": "${workspaceRoot}/out",
-            "cwd": "${workspaceRoot}"
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceFolder}/out/**/*.js" ],
         },
 		{
 			"name": "run tests on mac",
@@ -75,5 +74,11 @@
 			"outDir": "${workspaceRoot}/out",
 			"cwd": "${workspaceRoot}"
 		}
-    ]
+    ],
+	"compounds": [
+		{
+			"name": "Extension + Server",
+			"configurations": [ "launch in extension host", "launch as server" ]
+		}
+	]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "minNativescriptCliVersion": "2.5.0",
   "icon": "images/icon.png",
   "displayName": "NativeScript",
@@ -25,13 +25,14 @@
   ],
   "license": "SEE LICENSE IN LICENSE.txt",
   "dependencies": {
-    "vscode-chrome-debug-core": "~3.9.0",
     "node-ipc": "8.10.3",
     "source-map": "0.6.1",
-    "xmlhttprequest": "https://github.com/telerik/node-XMLHttpRequest/tarball/master",
+    "tree-kill": "^1.2.0",
     "universal-analytics": "0.4.13",
+    "vscode-chrome-debug-core": "~3.9.0",
     "vscode-debugadapter": "1.26.0",
-    "vscode-debugprotocol": "1.26.0"
+    "vscode-debugprotocol": "1.26.0",
+    "xmlhttprequest": "https://github.com/telerik/node-XMLHttpRequest/tarball/master"
   },
   "devDependencies": {
     "@types/mocha": "2.2.41",

--- a/src/debug-adapter/adapter/sourceMaps/sourceMapTransformer.ts
+++ b/src/debug-adapter/adapter/sourceMaps/sourceMapTransformer.ts
@@ -57,7 +57,7 @@ export class SourceMapTransformer implements DebugProtocol.IDebugTransformer {
     public setBreakpoints(args: DebugProtocol.ISetBreakpointsArgs, requestSeq: number): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             if (this._sourceMaps && args.source.path && path.extname(args.source.path) !== ".js") {
-                const argsPath = args.source.path;
+                const argsPath = utils.fixDriveLetterAndSlashes(args.source.path);
                 const mappedPath = this._sourceMaps.MapPathFromSource(argsPath);
                 if (mappedPath) {
                     Services.logger().log(`SourceMaps.setBP: Mapped ${argsPath} to ${mappedPath}`);

--- a/src/debug-adapter/webKitDebugAdapter.ts
+++ b/src/debug-adapter/webKitDebugAdapter.ts
@@ -16,6 +16,7 @@ import {formatConsoleMessage} from './consoleHelper';
 import {Services} from '../services/debugAdapterServices';
 import {LoggerHandler, Handlers, Tags} from '../common/logger';
 import {DebugRequest} from './debugRequest';
+import * as kill from 'tree-kill';
 
 interface IScopeVarHandle {
     objectId: string;
@@ -357,7 +358,7 @@ export class WebKitDebugAdapter implements DebugProtocol.IDebugAdapter {
     public disconnect(): Promise<void> {
         this.clearEverything();
         if (this._tnsProcess) {
-            this._tnsProcess.kill('SIGQUIT');
+            kill(this._tnsProcess.pid, 'SIGQUIT')
             this._tnsProcess = null;
         }
         if (this._webKitConnection) {

--- a/src/project/androidProject.ts
+++ b/src/project/androidProject.ts
@@ -47,13 +47,13 @@ export class AndroidProject extends Project {
             debugPort = parseInt((<string>match.matches[0]).match("(?:debug port: )([\\d]{5})")[1]);
             if (attach) {
                 // wait a little before trying to connect, this gives a chance for adb to be able to connect to the debug socket
-                setTimeout(() => { eventEmitter.emit('readyForConnection', debugPort); }, 500);
+                setTimeout(() => { eventEmitter.emit('readyForConnection', debugPort); }, 1000);
             }
         });
         if (!attach) {
             new scanner.StringMatchingScanner(readableStream).onEveryMatch('# NativeScript Debugger started #', (match: scanner.MatchFound) => {
                 // wait a little before trying to connect, this gives a chance for adb to be able to connect to the debug socket
-                setTimeout(() => { eventEmitter.emit('readyForConnection', debugPort); }, 500);
+                setTimeout(() => { eventEmitter.emit('readyForConnection', debugPort); }, 1000);
             });
         }
     }


### PR DESCRIPTION
- vscode seems to handle 'drive-letter' in both small letter and capital letter, this makes some conflict while dealing with breakpoints. Currently the _sourceMaps tree in sourceMapTransformer.ts has all paths with small letter but on the setBreakpoints method the debugger adapter receives a capital letter.

- Use tree-kill to kill the tns process because process kill throws an error "Unknown signal: SIGQUIT". Also on windows only the parent process is killed which in our case is the shell process which has started the "tns debug command". The actual node process remains.

- Increase time before "readyForConnection" event because in my tests it seems that 500 milliseconds are not enough.

- Remove some obsolete properties from launch.json and added a composite configuration for easier start/debugging.