### PR TITLE
Fixes LiveSync

### DIFF
--- a/src/debug-adapter/nativeScriptDebug.ts
+++ b/src/debug-adapter/nativeScriptDebug.ts
@@ -1,10 +1,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import { chromeConnection, ChromeDebugSession } from 'vscode-chrome-debug-core';
-import { AndroidProject } from '../project/androidProject';
-import { IosProject } from '../project/iosProject';
-import { NativeScriptCli } from '../project/nativeScriptCli';
-import { nativeScriptDebugAdapterGenerator } from './nativeScriptDebugAdapter';
+import { NativeScriptDebugAdapter } from './nativeScriptDebugAdapter';
 import { NativeScriptPathTransformer } from './nativeScriptPathTransformer';
 import { NativeScriptTargetDiscovery } from './nativeScriptTargetDiscovery';
 
@@ -16,7 +13,7 @@ class NSAndroidConnection extends chromeConnection.ChromeConnection {
 
 ChromeDebugSession.run(ChromeDebugSession.getSession(
     {
-        adapter: nativeScriptDebugAdapterGenerator(IosProject, AndroidProject, NativeScriptCli),
+        adapter: NativeScriptDebugAdapter,
         chromeConnection: NSAndroidConnection,
         extensionName: 'nativescript-extension',
         logFilePath: path.join(os.tmpdir(), 'nativescript-extension.txt'),

--- a/src/debug-adapter/nativeScriptDebugAdapter.ts
+++ b/src/debug-adapter/nativeScriptDebugAdapter.ts
@@ -135,4 +135,4 @@ export class NativeScriptDebugAdapter extends ChromeDebugAdapter {
             this._session.sendEvent(new Event(extProtocol.NS_DEBUG_ADAPTER_MESSAGE, request));
         });
     }
-};
+}

--- a/src/debug-adapter/nativeScriptDebugAdapter.ts
+++ b/src/debug-adapter/nativeScriptDebugAdapter.ts
@@ -1,145 +1,138 @@
-import { ChromeDebugAdapter, IRestartRequestArgs, logger } from 'vscode-chrome-debug-core';
+import { ChromeDebugAdapter, IRestartRequestArgs } from 'vscode-chrome-debug-core';
 import { Event, TerminatedEvent } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import * as extProtocol from '../common/extensionProtocol';
-import { AndroidProject } from '../project/androidProject';
-import { IosProject } from '../project/iosProject';
-import { NativeScriptCli } from '../project/nativeScriptCli';
 
 const reconnectAfterLiveSyncTimeout = 10 * 1000;
 
-export function nativeScriptDebugAdapterGenerator(iosProject: typeof IosProject,
-                                                  androidProject: typeof AndroidProject,
-                                                  nativeScriptCli: typeof NativeScriptCli) {
-    return class NativeScriptDebugAdapter extends ChromeDebugAdapter {
-        private _idCounter = 0;
-        private _pendingRequests: object = {};
-        private isLiveSync: boolean = false;
-        private portWaitingResolve: any;
-        private isDisconnecting: boolean = false;
+export class NativeScriptDebugAdapter extends ChromeDebugAdapter {
+    private _idCounter = 0;
+    private _pendingRequests: object = {};
+    private isLiveSync: boolean = false;
+    private portWaitingResolve: any;
+    private isDisconnecting: boolean = false;
 
-        public attach(args: any): Promise<void> {
-            return this.processRequestAndAttach(args);
+    public attach(args: any): Promise<void> {
+        return this.processRequestAndAttach(args);
+    }
+
+    public launch(args: any): Promise<void> {
+        return this.processRequestAndAttach(args);
+    }
+
+    public onPortReceived(port) {
+        this.portWaitingResolve && this.portWaitingResolve(port);
+    }
+
+    public onExtensionResponse(response) {
+        this._pendingRequests[response.requestId](response.result);
+        delete this._pendingRequests[response.requestId];
+    }
+
+    public disconnect(args: any): void {
+        this.isDisconnecting = true;
+        if (!args.restart) {
+            this.callRemoteMethod('buildService', 'disconnect');
         }
 
-        public launch(args: any): Promise<void> {
-            return this.processRequestAndAttach(args);
+        super.disconnect(args);
+    }
+
+    protected async terminateSession(reason: string, disconnectArgs?: DebugProtocol.DisconnectArguments, restart?: IRestartRequestArgs): Promise<void> {
+        let restartRequestArgs;
+        let timeoutId;
+
+        if (!this.isDisconnecting && this.isLiveSync) {
+            const portProm = new Promise<any>((res, rej) => {
+                this.portWaitingResolve = res;
+
+                timeoutId = setTimeout(() => {
+                    res();
+                }, reconnectAfterLiveSyncTimeout);
+            });
+
+            restartRequestArgs = await portProm;
+            clearTimeout(timeoutId);
         }
 
-        public onPortReceived(port) {
-            this.portWaitingResolve && this.portWaitingResolve(port);
-        }
+        await super.terminateSession(reason, disconnectArgs, restartRequestArgs);
+    }
 
-        public onExtensionResponse(response) {
-            this._pendingRequests[response.requestId](response.result);
-            delete this._pendingRequests[response.requestId];
-        }
+    protected hookConnectionEvents(): void {
+        super.hookConnectionEvents();
 
-        public disconnect(args: any): void {
-            this.isDisconnecting = true;
-            if (!args.restart) {
-                this.callRemoteMethod('buildService', 'disconnect');
+        this.chrome.Log.onEntryAdded((params) => this.onEntryAdded(params));
+    }
+
+    protected onEntryAdded(params: any): void {
+        if (params && params.entry && params.entry.level) {
+            const message = params.entry;
+
+            message.type = message.level;
+
+            const that = this as any;
+            const script = that.getScriptByUrl && that.getScriptByUrl(params.entry.url);
+
+            if (script) {
+                message.stack = {
+                    callFrames: [
+                        {
+                            columnNumber: 0,
+                            lineNumber: params.entry.lineNumber,
+                            scriptId: script.scriptId,
+                            url: params.entry.url,
+                        },
+                    ],
+                };
             }
 
-            super.disconnect(args);
-        }
-
-        protected async terminateSession(reason: string, disconnectArgs?: DebugProtocol.DisconnectArguments, restart?: IRestartRequestArgs): Promise<void> {
-            let restartRequestArgs;
-            let timeoutId;
-
-            if (!this.isDisconnecting && this.isLiveSync) {
-                const portProm = new Promise<any>((res, rej) => {
-                    this.portWaitingResolve = res;
-
-                    timeoutId = setTimeout(() => {
-                        res();
-                    }, reconnectAfterLiveSyncTimeout);
-                });
-
-                restartRequestArgs = await portProm;
-                clearTimeout(timeoutId);
-            }
-
-            await super.terminateSession(reason, disconnectArgs, restartRequestArgs);
-        }
-
-        protected hookConnectionEvents(): void {
-            super.hookConnectionEvents();
-
-            this.chrome.Log.onEntryAdded((params) => this.onEntryAdded(params));
-        }
-
-        protected onEntryAdded(params: any): void {
-            if (params && params.entry && params.entry.level) {
-                const message = params.entry;
-
-                message.type = message.level;
-
-                const that = this as any;
-                const script = that.getScriptByUrl && that.getScriptByUrl(params.entry.url);
-
-                if (script) {
-                    message.stack = {
-                        callFrames: [
-                            {
-                                columnNumber: 0,
-                                lineNumber: params.entry.lineNumber,
-                                scriptId: script.scriptId,
-                                url: params.entry.url,
-                            },
-                        ],
-                    };
-                }
-
-                this.onMessageAdded({
-                    message,
-                });
-            }
-        }
-
-        private async processRequestAndAttach(args: any) {
-            const transformedArgs = this.translateArgs(args);
-
-            if (args.__restart) {
-                transformedArgs.port = args.__restart.port;
-            } else {
-                this._session.sendEvent(new Event(extProtocol.BEFORE_DEBUG_START));
-                transformedArgs.port = await this.callRemoteMethod('buildService', 'processRequest', transformedArgs);
-            }
-
-            if (!transformedArgs.port) {
-                this._session.sendEvent(new TerminatedEvent());
-            }
-
-            (this.pathTransformer as any).setTargetPlatform(args.platform);
-            (ChromeDebugAdapter as any).SET_BREAKPOINTS_TIMEOUT = 20000;
-
-            this.isLiveSync = args.watch;
-
-            return super.attach(transformedArgs);
-        }
-
-        private translateArgs(args): any {
-            if (args.diagnosticLogging) {
-                args.trace = args.diagnosticLogging;
-            }
-
-            if (args.appRoot) {
-                args.webRoot = args.appRoot;
-            }
-
-            return args;
-        }
-
-        private callRemoteMethod<T>(service: string, method: string, ...args: any[]): Promise<T> {
-            const request: extProtocol.IRequest = { id: `req${++this._idCounter}`, service, method, args };
-
-            return new Promise<T>((res, rej) => {
-                this._pendingRequests[request.id] = res;
-
-                this._session.sendEvent(new Event(extProtocol.NS_DEBUG_ADAPTER_MESSAGE, request));
+            this.onMessageAdded({
+                message,
             });
         }
-    };
-}
+    }
+
+    private async processRequestAndAttach(args: any) {
+        const transformedArgs = this.translateArgs(args);
+
+        if (args.__restart) {
+            transformedArgs.port = args.__restart.port;
+        } else {
+            this._session.sendEvent(new Event(extProtocol.BEFORE_DEBUG_START));
+            transformedArgs.port = await this.callRemoteMethod('buildService', 'processRequest', transformedArgs);
+        }
+
+        if (!transformedArgs.port) {
+            this._session.sendEvent(new TerminatedEvent());
+        }
+
+        (this.pathTransformer as any).setTargetPlatform(args.platform);
+        (ChromeDebugAdapter as any).SET_BREAKPOINTS_TIMEOUT = 20000;
+
+        this.isLiveSync = args.watch;
+
+        return super.attach(transformedArgs);
+    }
+
+    private translateArgs(args): any {
+        if (args.diagnosticLogging) {
+            args.trace = args.diagnosticLogging;
+        }
+
+        if (args.appRoot) {
+            args.webRoot = args.appRoot;
+        }
+
+        return args;
+    }
+
+    private callRemoteMethod<T>(service: string, method: string, ...args: any[]): Promise<T> {
+        const request: extProtocol.IRequest = { id: `req${++this._idCounter}`, service, method, args };
+
+        return new Promise<T>((res, rej) => {
+            this._pendingRequests[request.id] = res;
+
+            this._session.sendEvent(new Event(extProtocol.NS_DEBUG_ADAPTER_MESSAGE, request));
+        });
+    }
+};

--- a/src/debug-adapter/nativeScriptDebugAdapter.ts
+++ b/src/debug-adapter/nativeScriptDebugAdapter.ts
@@ -1,22 +1,21 @@
-import { ChildProcess } from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
-import { ChromeDebugAdapter, logger } from 'vscode-chrome-debug-core';
-import { Event, OutputEvent, TerminatedEvent } from 'vscode-debugadapter';
+import { ChromeDebugAdapter, IRestartRequestArgs, logger } from 'vscode-chrome-debug-core';
+import { Event, TerminatedEvent } from 'vscode-debugadapter';
+import { DebugProtocol } from 'vscode-debugprotocol';
 import * as extProtocol from '../common/extensionProtocol';
-import * as utils from '../common/utilities';
 import { AndroidProject } from '../project/androidProject';
 import { IosProject } from '../project/iosProject';
 import { NativeScriptCli } from '../project/nativeScriptCli';
-import { IDebugResult } from '../project/project';
+
+const reconnectAfterLiveSyncTimeout = 10 * 1000;
 
 export function nativeScriptDebugAdapterGenerator(iosProject: typeof IosProject,
                                                   androidProject: typeof AndroidProject,
                                                   nativeScriptCli: typeof NativeScriptCli) {
     return class NativeScriptDebugAdapter extends ChromeDebugAdapter {
-        private _tnsProcess: ChildProcess;
         private _idCounter = 0;
         private _pendingRequests: object = {};
+        private isLiveSync: boolean = false;
+        private portWaitingResolve: any;
 
         public attach(args: any): Promise<void> {
             return this.processRequestAndAttach(args);
@@ -29,12 +28,13 @@ export function nativeScriptDebugAdapterGenerator(iosProject: typeof IosProject,
         public disconnect(args: any): void {
             super.disconnect(args);
 
-            if (this._tnsProcess) {
-                this._tnsProcess.stdout.removeAllListeners();
-                this._tnsProcess.stderr.removeAllListeners();
-                this._tnsProcess.removeAllListeners();
-                utils.killProcess(this._tnsProcess);
+            if (!args.restart) {
+                this.callRemoteMethod('buildService', 'disconnect');
             }
+        }
+
+        public onPortReceived(port) {
+            this.portWaitingResolve && this.portWaitingResolve(port);
         }
 
         public onExtensionResponse(response) {
@@ -42,87 +42,80 @@ export function nativeScriptDebugAdapterGenerator(iosProject: typeof IosProject,
             delete this._pendingRequests[response.requestId];
         }
 
+        protected async terminateSession(reason: string, disconnectArgs?: DebugProtocol.DisconnectArguments, restart?: IRestartRequestArgs): Promise<void> {
+            let restartRequestArgs;
+            let timeoutId;
+
+            if (this.isLiveSync) {
+                const portProm = new Promise<any>((res, rej) => {
+                    this. portWaitingResolve = res;
+
+                    timeoutId = setTimeout(() => {
+                        res();
+                    }, reconnectAfterLiveSyncTimeout);
+                });
+
+                restartRequestArgs = await portProm;
+                clearTimeout(timeoutId);
+            }
+
+            await super.terminateSession(reason, disconnectArgs, restartRequestArgs);
+        }
+
+        protected hookConnectionEvents(): void {
+            super.hookConnectionEvents();
+
+            this.chrome.Log.onEntryAdded((params) => this.onEntryAdded(params));
+        }
+
+        protected onEntryAdded(params: any): void {
+            if (params && params.entry && params.entry.level) {
+                const message = params.entry;
+
+                message.type = message.level;
+
+                const that = this as any;
+                const script = that.getScriptByUrl && that.getScriptByUrl(params.entry.url);
+
+                if (script) {
+                    message.stack = {
+                        callFrames: [
+                            {
+                                columnNumber: 0,
+                                lineNumber: params.entry.lineNumber,
+                                scriptId: script.scriptId,
+                                url: params.entry.url,
+                            },
+                        ],
+                    };
+                }
+
+                this.onMessageAdded({
+                    message,
+                });
+            }
+        }
+
         private async processRequestAndAttach(args: any) {
-            const transformedArgs = await this.processRequest(args);
+            const transformedArgs = this.translateArgs(args);
+
+            if (args.__restart) {
+                transformedArgs.port = args.__restart.port;
+            } else {
+                this._session.sendEvent(new Event(extProtocol.BEFORE_DEBUG_START));
+                transformedArgs.port = await this.callRemoteMethod('buildService', 'processRequest', transformedArgs);
+            }
+
+            if (!transformedArgs.port) {
+                this._session.sendEvent(new TerminatedEvent());
+            }
 
             (this.pathTransformer as any).setTargetPlatform(args.platform);
             (ChromeDebugAdapter as any).SET_BREAKPOINTS_TIMEOUT = 20000;
 
+            this.isLiveSync = args.watch;
+
             return super.attach(transformedArgs);
-        }
-
-        private async processRequest(args: any): Promise<any> {
-            args = this.translateArgs(args);
-
-            this._session.sendEvent(new Event(extProtocol.BEFORE_DEBUG_START));
-
-            const tnsPath = await this.callRemoteMethod<string>('workspaceConfigService', 'tnsPath');
-            const cli = new nativeScriptCli(tnsPath, logger);
-
-            const project = args.platform === 'ios' ?
-                new iosProject(args.appRoot, cli) :
-                new androidProject(args.appRoot, cli);
-
-            this.callRemoteMethod('analyticsService', 'launchDebugger', args.request, args.platform);
-
-            // Run CLI Command
-            const version = project.cli.executeGetVersion();
-
-            this.log(`[NSDebugAdapter] Using tns CLI v${version} on path '${project.cli.path}'\n`);
-            this.log('[NSDebugAdapter] Running tns command...\n');
-            let cliCommand: IDebugResult;
-
-            if (args.request === 'launch') {
-                let tnsArgs = args.tnsArgs;
-
-                // For iOS the TeamID is required if there's more than one.
-                // Therefore if not set, show selection to the user.
-                if (args.platform && args.platform.toLowerCase() === 'ios') {
-                    const teamId = this.getTeamId(path.join(args.appRoot, 'app'), tnsArgs);
-
-                    if (!teamId) {
-                        const selectedTeam = await this.callRemoteMethod<{ id: string, name: string }>('iOSTeamService', 'selectTeam');
-
-                        if (selectedTeam) {
-                            // add the selected by the user Team Id
-                            tnsArgs = (tnsArgs || []).concat(['--teamId', selectedTeam.id]);
-                            this.log(`[NSDebugAdapter] Using iOS Team ID '${selectedTeam.id}', you can change this in the workspace settings.\n`);
-                        }
-                    }
-                }
-
-                cliCommand = project.debug({ stopOnEntry: args.stopOnEntry, watch: args.watch }, tnsArgs);
-            } else if (args.request === 'attach') {
-                cliCommand = project.attach(args.tnsArgs);
-            }
-
-            if (cliCommand.tnsProcess) {
-                this._tnsProcess = cliCommand.tnsProcess;
-                cliCommand.tnsProcess.stdout.on('data', (data) => { this.log(data.toString()); });
-                cliCommand.tnsProcess.stderr.on('data', (data) => { this.log(data.toString()); });
-
-                cliCommand.tnsProcess.on('close', (code, signal) => {
-                    this.log(`[NSDebugAdapter] The tns command finished its execution with code ${code}.\n`);
-
-                    // Sometimes we execute "tns debug android --start" and the process finishes
-                    // which is totally fine. If there's an error we need to Terminate the session.
-                    if (code !== 0) {
-                        this.log(`The tns command finished its execution with code ${code}`);
-                        this._session.sendEvent(new TerminatedEvent());
-                    }
-                });
-            }
-
-            this.log('[NSDebugAdapter] Watching the tns CLI output to receive a connection token\n');
-
-            return new Promise<string | number> ((res, rej) => {
-                cliCommand.tnsOutputEventEmitter.on('readyForConnection', (connectionToken: string | number) => {
-                    this.log(`[NSDebugAdapter] Ready to attach to application on ${connectionToken}\n`);
-                    args.port = connectionToken;
-
-                    res(args);
-                });
-            });
         }
 
         private translateArgs(args): any {
@@ -135,65 +128,6 @@ export function nativeScriptDebugAdapterGenerator(iosProject: typeof IosProject,
             }
 
             return args;
-        }
-
-        private log(text: string): void {
-            this._session.sendEvent(new OutputEvent(text));
-        }
-
-        private getTeamId(appRoot: string, tnsArgs?: string[]): string {
-            // try to get the TeamId from the TnsArgs
-            if (tnsArgs) {
-                const teamIdArgIndex = tnsArgs.indexOf('--teamId');
-
-                if (teamIdArgIndex > 0 && teamIdArgIndex + 1 < tnsArgs.length) {
-                    return tnsArgs[ teamIdArgIndex + 1 ];
-                }
-            }
-
-            // try to get the TeamId from the buildxcconfig or teamid file
-            const teamIdFromConfig = this.readTeamId(appRoot);
-
-            if (teamIdFromConfig) {
-                return teamIdFromConfig;
-            }
-
-            // we should get the Teams from the machine and ask the user if they are more than 1
-            return null;
-        }
-
-        private readXCConfig(appRoot: string, flag: string): string {
-            const xcconfigFile = path.join(appRoot, 'App_Resources/iOS/build.xcconfig');
-
-            if (fs.existsSync(xcconfigFile)) {
-                const text = fs.readFileSync(xcconfigFile, { encoding: 'utf8'});
-                let teamId: string;
-
-                text.split(/\r?\n/).forEach((line) => {
-                    line = line.replace(/\/(\/)[^\n]*$/, '');
-                    if (line.indexOf(flag) >= 0) {
-                        teamId = line.split('=')[1].trim();
-                        if (teamId[teamId.length - 1] === ';') {
-                            teamId = teamId.slice(0, -1);
-                        }
-                    }
-                });
-                if (teamId) {
-                    return teamId;
-                }
-            }
-
-            const fileName = path.join(appRoot, 'teamid');
-
-            if (fs.existsSync(fileName)) {
-                return fs.readFileSync(fileName, { encoding: 'utf8' });
-            }
-
-            return null;
-        }
-
-        private readTeamId(appRoot): string {
-            return this.readXCConfig(appRoot, 'DEVELOPMENT_TEAM');
         }
 
         private callRemoteMethod<T>(service: string, method: string, ...args: any[]): Promise<T> {

--- a/src/debug-adapter/nativeScriptDebugAdapter.ts
+++ b/src/debug-adapter/nativeScriptDebugAdapter.ts
@@ -11,6 +11,7 @@ export class NativeScriptDebugAdapter extends ChromeDebugAdapter {
     private isLiveSync: boolean = false;
     private portWaitingResolve: any;
     private isDisconnecting: boolean = false;
+    private isLiveSyncRestart: boolean = false;
 
     public attach(args: any): Promise<void> {
         return this.processRequestAndAttach(args);
@@ -31,7 +32,7 @@ export class NativeScriptDebugAdapter extends ChromeDebugAdapter {
 
     public disconnect(args: any): void {
         this.isDisconnecting = true;
-        if (!args.restart) {
+        if (!this.isLiveSyncRestart) {
             this.callRemoteMethod('buildService', 'disconnect');
         }
 
@@ -39,7 +40,7 @@ export class NativeScriptDebugAdapter extends ChromeDebugAdapter {
     }
 
     protected async terminateSession(reason: string, disconnectArgs?: DebugProtocol.DisconnectArguments, restart?: IRestartRequestArgs): Promise<void> {
-        let restartRequestArgs;
+        let restartRequestArgs = restart;
         let timeoutId;
 
         if (!this.isDisconnecting && this.isLiveSync) {
@@ -52,6 +53,7 @@ export class NativeScriptDebugAdapter extends ChromeDebugAdapter {
             });
 
             restartRequestArgs = await portProm;
+            this.isLiveSyncRestart = restartRequestArgs && !!restartRequestArgs.port;
             clearTimeout(timeoutId);
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,6 +100,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(vscode.debug.onDidReceiveDebugSessionCustomEvent((event) => {
         if (event.event === extProtocol.BEFORE_DEBUG_START) {
+            channel.show();
             beforeBuildDisposables.forEach((disposable) => disposable.dispose());
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,7 +80,10 @@ export function activate(context: vscode.ExtensionContext) {
         });
 
         const disposable = {
-            dispose: () => utils.killProcess(tnsProcess),
+            dispose: () => {
+                services.buildService.disconnect();
+                utils.killProcess(tnsProcess);
+            },
         };
 
         context.subscriptions.push(disposable);

--- a/src/services/buildService.ts
+++ b/src/services/buildService.ts
@@ -1,0 +1,160 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as utils from '../common/utilities';
+
+import { ChildProcess } from 'child_process';
+import { ILogger } from '../common/logger';
+import { AndroidProject } from '../project/androidProject';
+import { IosProject } from '../project/iosProject';
+import { NativeScriptCli } from '../project/nativeScriptCli';
+import { IDebugResult } from '../project/project';
+import { services } from './extensionHostServices';
+
+export class BuildService {
+    private _tnsProcess: ChildProcess;
+    private _logger: ILogger;
+
+    constructor(logger: ILogger) {
+        this._logger = logger;
+    }
+
+    public async processRequest(args: any): Promise<any> {
+        const tnsPath = services.workspaceConfigService.tnsPath;
+        const cli = new NativeScriptCli(tnsPath, this._logger);
+
+        const project = args.platform === 'ios' ?
+            new IosProject(args.appRoot, cli) :
+            new AndroidProject(args.appRoot, cli);
+
+        services.analyticsService.launchDebugger(args.request, args.platform);
+
+        // Run CLI Command
+        const version = project.cli.executeGetVersion();
+
+        this._logger.log(`[NSDebugAdapter] Using tns CLI v${version} on path '${project.cli.path}'\n`);
+        this._logger.log('[NSDebugAdapter] Running tns command...\n');
+
+        let cliCommand: IDebugResult;
+
+        if (args.request === 'launch') {
+            let tnsArgs = args.tnsArgs;
+
+            // For iOS the TeamID is required if there's more than one.
+            // Therefore if not set, show selection to the user.
+            if (args.platform && args.platform.toLowerCase() === 'ios') {
+                const teamId = this.getTeamId(path.join(args.appRoot, 'app'), tnsArgs);
+
+                if (!teamId) {
+                    const selectedTeam = await services.iOSTeamService.selectTeam();
+
+                    if (selectedTeam) {
+                        // add the selected by the user Team Id
+                        tnsArgs = (tnsArgs || []).concat(['--teamId', selectedTeam.id]);
+                        this._logger.log(`[NSDebugAdapter] Using iOS Team ID '${selectedTeam.id}', you can change this in the workspace settings.\n`);
+                    }
+                }
+            }
+
+            cliCommand = project.debug({ stopOnEntry: args.stopOnEntry, watch: args.watch }, tnsArgs);
+        } else if (args.request === 'attach') {
+            cliCommand = project.attach(args.tnsArgs);
+        }
+
+        return new Promise<string | number> ((res, rej) => {
+            if (cliCommand.tnsProcess) {
+                this._tnsProcess = cliCommand.tnsProcess;
+                cliCommand.tnsProcess.stdout.on('data', (data) => { this._logger.log(data.toString()); });
+                cliCommand.tnsProcess.stderr.on('data', (data) => { this._logger.log(data.toString()); });
+
+                cliCommand.tnsProcess.on('close', (code, signal) => {
+                    this._logger.log(`[NSDebugAdapter] The tns command finished its execution with code ${code}.\n`);
+
+                    // Sometimes we execute "tns debug android --start" and the process finishes
+                    // which is totally fine. If there's an error we need to Terminate the session.
+                    if (code !== 0) {
+                        const errorMessage = `The tns command finished its execution with code ${code}`;
+
+                        this._logger.log(errorMessage);
+
+                        res();
+                    }
+                });
+            }
+
+            this._logger.log('[NSDebugAdapter] Watching the tns CLI output to receive a connection token\n');
+
+            cliCommand.tnsOutputEventEmitter.on('readyForConnection', (connectionToken: string | number) => {
+                this._logger.log(`[NSDebugAdapter] Ready to attach to application on ${connectionToken}\n`);
+                args.port = connectionToken;
+                vscode.debug.activeDebugSession && vscode.debug.activeDebugSession.customRequest('onPortReceived', { port: connectionToken });
+
+                res(connectionToken);
+            });
+        });
+    }
+
+    public disconnect(): void {
+        if (this._tnsProcess) {
+            this._tnsProcess.stdout.removeAllListeners();
+            this._tnsProcess.stderr.removeAllListeners();
+            this._tnsProcess.removeAllListeners();
+            utils.killProcess(this._tnsProcess);
+        }
+    }
+
+    private getTeamId(appRoot: string, tnsArgs?: string[]): string {
+        // try to get the TeamId from the TnsArgs
+        if (tnsArgs) {
+            const teamIdArgIndex = tnsArgs.indexOf('--teamId');
+
+            if (teamIdArgIndex > 0 && teamIdArgIndex + 1 < tnsArgs.length) {
+                return tnsArgs[ teamIdArgIndex + 1 ];
+            }
+        }
+
+        // try to get the TeamId from the buildxcconfig or teamid file
+        const teamIdFromConfig = this.readTeamId(appRoot);
+
+        if (teamIdFromConfig) {
+            return teamIdFromConfig;
+        }
+
+        // we should get the Teams from the machine and ask the user if they are more than 1
+        return null;
+    }
+
+    private readXCConfig(appRoot: string, flag: string): string {
+        const xcconfigFile = path.join(appRoot, 'App_Resources/iOS/build.xcconfig');
+
+        if (fs.existsSync(xcconfigFile)) {
+            const text = fs.readFileSync(xcconfigFile, { encoding: 'utf8'});
+            let teamId: string;
+
+            text.split(/\r?\n/).forEach((line) => {
+                line = line.replace(/\/(\/)[^\n]*$/, '');
+                if (line.indexOf(flag) >= 0) {
+                    teamId = line.split('=')[1].trim();
+                    if (teamId[teamId.length - 1] === ';') {
+                        teamId = teamId.slice(0, -1);
+                    }
+                }
+            });
+            if (teamId) {
+                return teamId;
+            }
+        }
+
+        const fileName = path.join(appRoot, 'teamid');
+
+        if (fs.existsSync(fileName)) {
+            return fs.readFileSync(fileName, { encoding: 'utf8' });
+        }
+
+        return null;
+    }
+
+    private readTeamId(appRoot): string {
+        return this.readXCConfig(appRoot, 'DEVELOPMENT_TEAM');
+    }
+}

--- a/src/services/extensionHostServices.ts
+++ b/src/services/extensionHostServices.ts
@@ -3,6 +3,7 @@ import { AnalyticsService } from '../analytics/analyticsService';
 import { WorkspaceConfigService } from '../common/workspaceConfigService';
 import { iOSTeamService } from './iOSTeamService';
 import { Services as BaseServices } from './services';
+import { BuildService } from "./buildService";
 
 export class ExtensionHostServices extends BaseServices {
     public cliVersion: string;
@@ -13,6 +14,7 @@ export class ExtensionHostServices extends BaseServices {
     private _workspaceConfigService: WorkspaceConfigService;
     private _iOSTeamService: iOSTeamService;
     private _analyticsService: AnalyticsService;
+    private _buildService: BuildService;
 
     public get globalState(): vscode.Memento { return this._globalState; }
 
@@ -34,6 +36,12 @@ export class ExtensionHostServices extends BaseServices {
         this._analyticsService = this._analyticsService || new AnalyticsService(this.globalState, this.cliVersion, this.extensionVersion, this._logger);
 
         return this._analyticsService;
+    }
+
+    public get buildService(): BuildService {
+        this._buildService = this._buildService || new BuildService(this._logger);
+
+        return this._buildService;
     }
 }
 

--- a/src/services/extensionHostServices.ts
+++ b/src/services/extensionHostServices.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode';
 import { AnalyticsService } from '../analytics/analyticsService';
 import { WorkspaceConfigService } from '../common/workspaceConfigService';
+import { BuildService } from './buildService';
 import { iOSTeamService } from './iOSTeamService';
 import { Services as BaseServices } from './services';
-import { BuildService } from "./buildService";
 
 export class ExtensionHostServices extends BaseServices {
     public cliVersion: string;


### PR DESCRIPTION
Fixes LiveSync by restarting session. Each time we got terminate sessions event we wait 10 sec to get new port. If we get new port for debugging we restart the session.

Move cli process to main process because each restart the session is created(but the tns process is not killed) and we don't have reference to the long running tns process. Also conceptual it's better to have the cli output in the extension output but not in the debug console.

Fixes Debug Console messages and show exactly in which file is the console log.