### PR TITLE
fix: debugging is not working when app path is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.8.2
+=====
+## Bug Fixes
+ - [Unable to debug when project's app directory is renamed](https://github.com/NativeScript/nativescript-vscode-extension/issues/205)
+
 0.8.1
 =====
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "minNativescriptCliVersion": "2.5.0",
   "icon": "images/icon.png",
   "displayName": "NativeScript",

--- a/src/debug-adapter/nativeScriptPathTransformer.ts
+++ b/src/debug-adapter/nativeScriptPathTransformer.ts
@@ -42,6 +42,21 @@ export class NativeScriptPathTransformer extends UrlPathTransformer {
 
         relativePath = relativePath.replace('tns_modules', nodePath);
 
+        const pathToNsconfig = path.join(webRoot, 'nsconfig.json');
+
+        if (fs.existsSync(pathToNsconfig)) {
+            try {
+                const content = fs.readFileSync(pathToNsconfig).toString();
+                const jsonContent = JSON.parse(content);
+
+                if (jsonContent.appPath) {
+                    relativePath = relativePath.replace('app', jsonContent.appPath);
+                }
+            } catch (err) {
+                // Ignore the error for the moment
+            }
+        }
+
         const absolutePath = path.resolve(path.join(webRoot, relativePath));
 
         if (fs.existsSync(absolutePath)) {

--- a/src/debug-adapter/nativeScriptPathTransformer.ts
+++ b/src/debug-adapter/nativeScriptPathTransformer.ts
@@ -10,9 +10,11 @@ export class NativeScriptPathTransformer extends UrlPathTransformer {
     };
 
     private targetPlatform: string;
+    private appDirPath: string;
 
-    public setTargetPlatform(targetPlatform: string) {
+    public setTransformOptions(targetPlatform: string, appDirPath: string) {
         this.targetPlatform = targetPlatform.toLowerCase();
+        this.appDirPath = appDirPath;
     }
 
     protected async targetUrlToClientPath(webRoot: string, scriptUrl: string): Promise<string> {
@@ -42,19 +44,8 @@ export class NativeScriptPathTransformer extends UrlPathTransformer {
 
         relativePath = relativePath.replace('tns_modules', nodePath);
 
-        const pathToNsconfig = path.join(webRoot, 'nsconfig.json');
-
-        if (fs.existsSync(pathToNsconfig)) {
-            try {
-                const content = fs.readFileSync(pathToNsconfig).toString();
-                const jsonContent = JSON.parse(content);
-
-                if (jsonContent.appPath) {
-                    relativePath = relativePath.replace('app', jsonContent.appPath);
-                }
-            } catch (err) {
-                // Ignore the error for the moment
-            }
+        if (this.appDirPath) {
+            relativePath = relativePath.replace('app', this.appDirPath);
         }
 
         const absolutePath = path.resolve(path.join(webRoot, relativePath));

--- a/src/tests/nativeScriptDebugAdapter.tests.ts
+++ b/src/tests/nativeScriptDebugAdapter.tests.ts
@@ -58,7 +58,7 @@ describe('NativeScriptDebugAdapter', () => {
         pathTransformerMock = {
             attach: () => ({}),
             clearTargetContext: () => ({}),
-            setTargetPlatform: () => ({}),
+            setTransformOptions: () => ({}),
         };
 
         nativeScriptDebugAdapter = new NativeScriptDebugAdapter(
@@ -84,8 +84,8 @@ describe('NativeScriptDebugAdapter', () => {
                 sinon.assert.calledWith(spy, sinon.match({ event: extProtocol.BEFORE_DEBUG_START }));
             });
 
-            it(`${method} for ${platform} should call project setTargetPlatform`, async () => {
-                const spy = sinon.spy(pathTransformerMock, 'setTargetPlatform');
+            it(`${method} for ${platform} should call project setTransformOptions`, async () => {
+                const spy = sinon.spy(pathTransformerMock, 'setTransformOptions');
 
                 await nativeScriptDebugAdapter[method](argsMock);
 

--- a/src/tests/nativeScriptPathTransformer.tests.ts
+++ b/src/tests/nativeScriptPathTransformer.tests.ts
@@ -8,7 +8,6 @@ import * as tests from './pathTransformData';
 describe('NativeScriptPathTransformer', () => {
     let nativeScriptPathTransformer: any;
     let existsSyncStub;
-    let readFileSyncStub;
 
     before(() => {
         nativeScriptPathTransformer = new NativeScriptPathTransformer();
@@ -23,17 +22,11 @@ describe('NativeScriptPathTransformer', () => {
             it(`should transform [${test.platform}] device path ${test.scriptUrl} -> ${test.expectedResult}${nsConfigPartInTestName}`, async () => {
                 (path as any).join = path.win32.join;
                 (path as any).resolve = path.win32.resolve;
-                (path as any).basename = path.win32.basename;
-                nativeScriptPathTransformer.setTargetPlatform(test.platform);
-                const isNsconfigFilePath = (filePath: string) => path.basename(filePath) === 'nsconfig.json';
+                nativeScriptPathTransformer.setTransformOptions(test.platform, test.nsconfig ? test.nsconfig.appPath : null);
 
                 existsSyncStub = sinon
                     .stub(fs, 'existsSync')
-                    .callsFake((arg: string) => arg === test.existingPath || (test.nsconfig && isNsconfigFilePath(arg)));
-                readFileSyncStub = sinon
-                    .stub(fs, 'readFileSync')
-                    .callsFake((filePath: string) => (isNsconfigFilePath(filePath) && test.nsconfig) ? JSON.stringify(test.nsconfig) : null);
-
+                    .callsFake((arg: string) => arg === test.existingPath);
                 const result = await nativeScriptPathTransformer.targetUrlToClientPath(webRoot, test.scriptUrl);
 
                 assert.equal(result, test.expectedResult);
@@ -42,7 +35,6 @@ describe('NativeScriptPathTransformer', () => {
 
         afterEach(() => {
             existsSyncStub.restore();
-            readFileSyncStub.restore();
         });
     });
 

--- a/src/tests/pathTransformData.ts
+++ b/src/tests/pathTransformData.ts
@@ -15,6 +15,9 @@ const tests = [
     { platform: 'android', scriptUrl: 'file:///data/data/org.nativescript.TabNavigation/files/app/tns_modules/tns-core-modules/ui/page/page.js', expectedResult: 'C:\\projectpath\\node_modules\\tns-core-modules\\ui\\page\\page.android.js', existingPath: 'C:\\projectpath\\node_modules\\tns-core-modules\\ui\\page\\page.android.js' },
     { platform: 'android', scriptUrl: 'file:///data/data/org.nativescript.TabNavigation/files/app/tns_modules/tns-core-modules/ui/layouts/layout-base.js', expectedResult: 'C:\\projectpath\\node_modules\\tns-core-modules\\ui\\layouts\\layout-base.android.js', existingPath: 'C:\\projectpath\\node_modules\\tns-core-modules\\ui\\layouts\\layout-base.android.js' },
     { platform: 'android', scriptUrl: 'ng:///css/0/data/data/org.nativescript.TabNavigation/files/app/tabs/tabs.component.scss.ngstyle.js', expectedResult: 'ng:///css/0/data/data/org.nativescript.TabNavigation/files/app/tabs/tabs.component.scss.ngstyle.js' },
+    { platform: 'android', scriptUrl: 'file:///data/data/org.nativescript.TabNavigation/files/app/main.js', expectedResult: 'C:\\projectpath\\src\\main.js', nsconfig: { appPath: 'src' },  existingPath: 'C:\\projectpath\\src\\main.js' },
+    { platform: 'android', scriptUrl: 'file:///data/data/org.nativescript.TabNavigation/files/app/app/main.js', expectedResult: 'C:\\projectpath\\src\\app\\main.js', nsconfig: { appPath: 'src' },  existingPath: 'C:\\projectpath\\src\\app\\main.js' },
+    { platform: 'android', scriptUrl: 'file:///data/data/org.nativescript.app1/files/app/app/main.js', expectedResult: 'C:\\projectpath\\src\\app\\main.js', nsconfig: { appPath: 'src' },  existingPath: 'C:\\projectpath\\src\\app\\main.js' },
 ];
 
 export = tests;


### PR DESCRIPTION
Debugging is not working when project has `nsconfig.json` and the path to `app` directory is changed. The problem is that on device the directory is always called `app`, but NativeScript projects can rename it locally to `src` for example.
In order to fix the issue, check if there's nsconfig.json file and replace the `app` from the device path with the local name of the app directory.

This fixes debugging for new Angular templates.

Fix for https://github.com/NativeScript/nativescript-vscode-extension/issues/205