### PR TITLE
Fix debugger hangs if build of app fails

### DIFF
--- a/src/services/buildService.ts
+++ b/src/services/buildService.ts
@@ -76,9 +76,9 @@ export class BuildService {
                         const errorMessage = `The tns command finished its execution with code ${code}`;
 
                         this._logger.log(errorMessage);
-
-                        res();
                     }
+
+                    res();
                 });
             }
 


### PR DESCRIPTION
We wait for port to attach from the CLI and if the port is null we stop the attach process. If the CLI exit with non zero code we send empty port so the debugger is stopped.
Now stop debugging each time CLI exits when it's an initial start state.

Fixes https://github.com/NativeScript/nativescript-vscode-extension/issues/206