### PR TITLE
fix: set correct source map path for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,10 +140,7 @@
             "platform": "ios",
             "appRoot": "${workspaceRoot}",
             "sourceMaps": true,
-            "watch": true,
-            "sourceMapPathOverrides": {
-               "webpack:///*": "${workspaceRoot}/src/*"
-            }
+            "watch": true
           },
           {
             "name": "Attach on iOS",
@@ -152,10 +149,7 @@
             "platform": "ios",
             "appRoot": "${workspaceRoot}",
             "sourceMaps": true,
-            "watch": false,
-            "sourceMapPathOverrides": {
-               "webpack:///*": "${workspaceRoot}/src/*"
-            }
+            "watch": false
           },
           {
             "name": "Launch on Android",
@@ -164,10 +158,7 @@
             "platform": "android",
             "appRoot": "${workspaceRoot}",
             "sourceMaps": true,
-            "watch": true,
-            "sourceMapPathOverrides": {
-               "webpack:///*": "${workspaceRoot}/src/*"
-            }
+            "watch": true
           },
           {
             "name": "Attach on Android",
@@ -176,10 +167,7 @@
             "platform": "android",
             "appRoot": "${workspaceRoot}",
             "sourceMaps": true,
-            "watch": false,
-            "sourceMapPathOverrides": {
-               "webpack:///*": "${workspaceRoot}/src/*"
-            }
+            "watch": false
           }
         ],
         "configurationSnippets": [
@@ -193,10 +181,7 @@
               "platform": "ios",
               "appRoot": "^\"\\${workspaceRoot}\"",
               "sourceMaps": true,
-              "watch": true,
-              "sourceMapPathOverrides": {
-                 "webpack:///*": "${workspaceRoot}/src/*"
-              }
+              "watch": true
             }
           },
           {
@@ -209,10 +194,7 @@
               "platform": "android",
               "appRoot": "^\"\\${workspaceRoot}\"",
               "sourceMaps": true,
-              "watch": true,
-              "sourceMapPathOverrides": {
-                 "webpack:///*": "${workspaceRoot}/src/*"
-              }
+              "watch": true
             }
           },
           {
@@ -225,10 +207,7 @@
               "platform": "ios",
               "appRoot": "^\"\\${workspaceRoot}\"",
               "sourceMaps": true,
-              "watch": false,
-              "sourceMapPathOverrides": {
-                 "webpack:///*": "${workspaceRoot}/src/*"
-              }
+              "watch": false
             }
           },
           {
@@ -241,10 +220,7 @@
               "platform": "android",
               "appRoot": "^\"\\${workspaceRoot}\"",
               "sourceMaps": true,
-              "watch": false,
-              "sourceMapPathOverrides": {
-                 "webpack:///*": "${workspaceRoot}/src/*"
-              }
+              "watch": false
             }
           }
         ],

--- a/src/debug-adapter/nativeScriptDebugAdapter.ts
+++ b/src/debug-adapter/nativeScriptDebugAdapter.ts
@@ -144,6 +144,17 @@ export class NativeScriptDebugAdapter extends ChromeDebugAdapter {
             args.webRoot = args.appRoot;
         }
 
+        if (!args.sourceMapPathOverrides) {
+            args.sourceMapPathOverrides = { };
+        }
+
+        if (!args.sourceMapPathOverrides['webpack:///*']) {
+            const appDirPath = this.getAppDirPath(args.webRoot) || 'app';
+            const fullAppDirPath = join(args.webRoot, appDirPath);
+
+            args.sourceMapPathOverrides['webpack:///*'] = `${fullAppDirPath}/*`;
+        }
+
         return args;
     }
 


### PR DESCRIPTION
Currently source map path for webpack is set to `src` which is not correct for js projects and in case when the user changes appDirPath property in `nsconfig` file.

Rel to: https://github.com/NativeScript/nativescript-vscode-extension/issues/222