### PR TITLE
fix: increase timeout for reconnecting

### DIFF
--- a/src/debug-adapter/nativeScriptDebugAdapter.ts
+++ b/src/debug-adapter/nativeScriptDebugAdapter.ts
@@ -5,7 +5,7 @@ import { Event, TerminatedEvent } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import * as extProtocol from '../common/extensionProtocol';
 
-const reconnectAfterLiveSyncTimeout = 10 * 1000;
+const reconnectAfterLiveSyncTimeout = 30 * 1000;
 
 export class NativeScriptDebugAdapter extends ChromeDebugAdapter {
     private _idCounter = 0;


### PR DESCRIPTION
Increase the timeout for reconnect after liveSync. Currently, if you have stopped on a breakpoint and apply a change in the code (for iOS), the session will not be able to restart for 10 seconds. So increase the timeout as a temp solution for the moment.