### PR TITLE
fix: use strict versions for all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,28 +25,28 @@
   ],
   "license": "SEE LICENSE IN LICENSE.txt",
   "dependencies": {
-    "lodash": "^4.17.10",
-    "semver": "^5.5.0",
+    "lodash": "4.17.11",
+    "semver": "5.6.0",
     "universal-analytics": "0.4.15",
-    "uuid": "^3.2.1",
-    "vscode-chrome-debug-core": "^3.23.11",
-    "vscode-debugadapter": "^1.28.0-pre.2"
+    "uuid": "3.3.2",
+    "vscode-chrome-debug-core": "3.23.11",
+    "vscode-debugadapter": "1.34.0"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.109",
-    "@types/mocha": "^5.2.1",
+    "@types/lodash": "4.14.121",
+    "@types/mocha": "5.2.6",
     "@types/node": "6.0.46",
-    "@types/semver": "^5.5.0",
+    "@types/semver": "5.5.0",
     "@types/universal-analytics": "0.4.1",
-    "cpx": "^1.5.0",
-    "mocha": "^5.2.0",
-    "sinon": "^5.0.10",
+    "cpx": "1.5.0",
+    "mocha": "5.2.0",
+    "sinon": "5.1.1",
     "tslint": "5.10.0",
-    "tslint-eslint-rules": "^5.3.1",
+    "tslint-eslint-rules": "5.4.0",
     "typescript": "2.6.2",
     "vsce": "~1.36.0",
     "vscode": "~1.1.10",
-    "vscode-debugprotocol": "^1.28.0-pre.1"
+    "vscode-debugprotocol": "1.34.0"
   },
   "scripts": {
     "clean": "git clean -fdx",


### PR DESCRIPTION
Currently build of the extension fails as the versions of dependencies and devDependencies are not hardcoded and we receive version of `@types/lodash` that is incompatible with the TypeScript we are using.
For `@types/lodash` we have the following dist-tags:
```
{ latest: '4.14.122',
  'ts2.0': '4.14.50',
  'ts2.1': '4.14.56',
  'ts2.2': '4.14.112',
  'ts2.3': '4.14.112',
  'ts2.4': '4.14.112',
  'ts2.5': '4.14.112',
  'ts2.6': '4.14.121',
  'ts2.7': '4.14.121',
  'ts2.8': '4.14.122',
  'ts2.9': '4.14.122',
  'ts3.0': '4.14.122',
  'ts3.1': '4.14.122',
  'ts3.2': '4.14.122',
  'ts3.3': '4.14.122',
  'ts3.4': '4.14.122' }
```

In our case we are using TypeScript 2.6.2, so set the version of `@types/lodash` to 4.14.121.
Also set strict versions for all other dependencies (based on what has been installed in my local `node_modules` dir).