### PR TITLE
chore: update chrome-debug-adapter to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "semver": "5.6.0",
     "universal-analytics": "0.4.15",
     "uuid": "3.3.2",
-    "vscode-chrome-debug-core": "3.23.11",
+    "vscode-chrome-debug-core": "6.7.45",
     "vscode-debugadapter": "1.34.0"
   },
   "devDependencies": {
@@ -44,8 +44,8 @@
     "tslint": "5.10.0",
     "tslint-eslint-rules": "5.4.0",
     "typescript": "2.6.2",
-    "vsce": "~1.36.0",
-    "vscode": "~1.1.10",
+    "vsce": "1.57.1",
+    "vscode": "1.1.30",
     "vscode-debugprotocol": "1.34.0"
   },
   "scripts": {

--- a/src/debug-adapter/nativeScriptDebugAdapter.ts
+++ b/src/debug-adapter/nativeScriptDebugAdapter.ts
@@ -65,7 +65,7 @@ export class NativeScriptDebugAdapter extends ChromeDebugAdapter {
     protected hookConnectionEvents(): void {
         super.hookConnectionEvents();
 
-        this.chrome.Log.onEntryAdded((params) => this.onEntryAdded(params));
+        this.chrome.Log.on('entryAdded', (params) => this.onEntryAdded(params));
     }
 
     protected onEntryAdded(params: any): void {
@@ -112,7 +112,7 @@ export class NativeScriptDebugAdapter extends ChromeDebugAdapter {
 
         const appDirPath = this.getAppDirPath(transformedArgs.webRoot);
 
-        (this.pathTransformer as any).setTransformOptions(args.platform, appDirPath);
+        (this.pathTransformer as any).setTransformOptions(args.platform, appDirPath, transformedArgs.webRoot);
         (ChromeDebugAdapter as any).SET_BREAKPOINTS_TIMEOUT = 20000;
 
         this.isLiveSync = args.watch;

--- a/src/debug-adapter/nativeScriptPathTransformer.ts
+++ b/src/debug-adapter/nativeScriptPathTransformer.ts
@@ -11,13 +11,15 @@ export class NativeScriptPathTransformer extends UrlPathTransformer {
 
     private targetPlatform: string;
     private appDirPath: string;
+    private webRoot: string;
 
-    public setTransformOptions(targetPlatform: string, appDirPath: string) {
+    public setTransformOptions(targetPlatform: string, appDirPath: string, webRoot: string) {
         this.targetPlatform = targetPlatform.toLowerCase();
         this.appDirPath = appDirPath;
+        this.webRoot = webRoot;
     }
 
-    protected async targetUrlToClientPath(webRoot: string, scriptUrl: string): Promise<string> {
+    protected async targetUrlToClientPath(scriptUrl: string): Promise<string> {
         if (!scriptUrl) {
             return;
         }
@@ -50,7 +52,7 @@ export class NativeScriptPathTransformer extends UrlPathTransformer {
             relativePath = relativePath.replace('app', this.appDirPath);
         }
 
-        let absolutePath = path.resolve(path.join(webRoot, relativePath));
+        let absolutePath = path.resolve(path.join(this.webRoot, relativePath));
         let platformSpecificPath = this.getPlatformSpecificPath(absolutePath);
 
         if (platformSpecificPath) {
@@ -59,7 +61,7 @@ export class NativeScriptPathTransformer extends UrlPathTransformer {
 
         if (isAndroid) {
             // handle files like /data/data/internal/ts_helpers.ts
-            absolutePath = path.resolve(path.join(webRoot, 'platforms', this.targetPlatform.toLowerCase(), 'app', 'src', 'main', 'assets', relativePath));
+            absolutePath = path.resolve(path.join(this.webRoot, 'platforms', this.targetPlatform.toLowerCase(), 'app', 'src', 'main', 'assets', relativePath));
             platformSpecificPath = this.getPlatformSpecificPath(absolutePath);
 
             if (platformSpecificPath) {

--- a/src/debug-adapter/nativeScriptTargetDiscovery.ts
+++ b/src/debug-adapter/nativeScriptTargetDiscovery.ts
@@ -13,6 +13,7 @@ export class NativeScriptTargetDiscovery extends chromeTargetDiscoveryStrategy.C
             id: uuid.v4(),
             title: 'NS Debug Target',
             type: 'node',
+            version: null,
             webSocketDebuggerUrl: `ws://${address}:${port}`,
         });
     }

--- a/src/tests/nativeScriptPathTransformer.tests.ts
+++ b/src/tests/nativeScriptPathTransformer.tests.ts
@@ -22,12 +22,12 @@ describe('NativeScriptPathTransformer', () => {
             it(`should transform [${test.platform}] device path ${test.scriptUrl} -> ${test.expectedResult}${nsConfigPartInTestName}`, async () => {
                 (path as any).join = path.win32.join;
                 (path as any).resolve = path.win32.resolve;
-                nativeScriptPathTransformer.setTransformOptions(test.platform, test.nsconfig ? test.nsconfig.appPath : null);
+                nativeScriptPathTransformer.setTransformOptions(test.platform, test.nsconfig ? test.nsconfig.appPath : null, webRoot);
 
                 existsSyncStub = sinon
                     .stub(fs, 'existsSync')
                     .callsFake((arg: string) => arg === test.existingPath);
-                const result = await nativeScriptPathTransformer.targetUrlToClientPath(webRoot, test.scriptUrl);
+                const result = await nativeScriptPathTransformer.targetUrlToClientPath(test.scriptUrl);
 
                 assert.equal(result, test.expectedResult);
             });


### PR DESCRIPTION
Update chrome-debug-adapter package to latest version and apply required changes in the code according to the changes in the new version.
As the webRoot is no longer passed to `targetUrlToClientPath` method, set the webRoot when initializing the instance of `NativeScriptPathTransformer`