### PR TITLE
feat: add support for debug with hmr

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "semver": "5.6.0",
     "universal-analytics": "0.4.15",
     "uuid": "3.3.2",
-    "vscode-chrome-debug-core": "6.7.45",
+    "vscode-chrome-debug-core": "6.7.46",
     "vscode-debugadapter": "1.34.0"
   },
   "devDependencies": {

--- a/src/debug-adapter/nativeScriptDebug.ts
+++ b/src/debug-adapter/nativeScriptDebug.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { chromeConnection, ChromeDebugSession } from 'vscode-chrome-debug-core';
 import { NativeScriptDebugAdapter } from './nativeScriptDebugAdapter';
 import { NativeScriptPathTransformer } from './nativeScriptPathTransformer';
+import { NativeScriptSourceMapTransformer } from './nativeScriptSourceMapTransformer';
 import { NativeScriptTargetDiscovery } from './nativeScriptTargetDiscovery';
 
 class NSAndroidConnection extends chromeConnection.ChromeConnection {
@@ -18,4 +19,5 @@ ChromeDebugSession.run(ChromeDebugSession.getSession(
         extensionName: 'nativescript-extension',
         logFilePath: path.join(os.tmpdir(), 'nativescript-extension.txt'),
         pathTransformer: NativeScriptPathTransformer,
+        sourceMapTransformer: NativeScriptSourceMapTransformer,
     }));

--- a/src/debug-adapter/nativeScriptSourceMapTransformer.ts
+++ b/src/debug-adapter/nativeScriptSourceMapTransformer.ts
@@ -1,0 +1,26 @@
+import { BaseSourceMapTransformer } from 'vscode-chrome-debug-core';
+import { NativeScriptDebugAdapter } from './nativeScriptDebugAdapter';
+
+export class NativeScriptSourceMapTransformer extends BaseSourceMapTransformer {
+    private debugAdapter: NativeScriptDebugAdapter;
+
+    constructor(sourceHandles: any) {
+        super(sourceHandles);
+    }
+
+    public setDebugAdapter(debugAdapter: NativeScriptDebugAdapter): void {
+        this.debugAdapter = debugAdapter;
+    }
+
+    public async scriptParsed(pathToGenerated: string, sourceMapURL: string): Promise<string[]> {
+        const scriptParsedResult = await super.scriptParsed(pathToGenerated, sourceMapURL);
+
+        if (scriptParsedResult && scriptParsedResult.length) {
+            for (const script of scriptParsedResult) {
+                await this.debugAdapter.setCachedBreakpointsForScript(script);
+            }
+        }
+
+        return scriptParsedResult;
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -110,8 +110,8 @@ export function activate(context: vscode.ExtensionContext) {
             const method = service[request.method];
             const response = typeof method === 'function' ? service[request.method].call(service, ...request.args) : method;
 
-            if (response.then) {
-                response.then((result) => event.session.customRequest('onExtensionResponse', { requestId: request.id, result }),
+            if (response && response.then) {
+                response.then((result) => event.session && event.session.customRequest('onExtensionResponse', { requestId: request.id, result }),
                     (err: Error) => {
                         vscode.window.showErrorMessage(err.message);
                         event.session.customRequest('onExtensionResponse', { requestId: request.id, isError: true, message: err.message });

--- a/src/tests/nativeScriptDebugAdapter.tests.ts
+++ b/src/tests/nativeScriptDebugAdapter.tests.ts
@@ -22,7 +22,7 @@ const defaultArgsMock: any = {
     platform: 'android',
     request: 'attach',
     stopOnEntry: true,
-    tnsArgs: [ 'mockArgs'],
+    tnsArgs: ['mockArgs'],
     watch: true,
 };
 
@@ -37,6 +37,7 @@ describe('NativeScriptDebugAdapter', () => {
     let chromeSessionMock: any;
     let chromeConnectionMock: any;
     let pathTransformerMock: any;
+    let sourceMapTransformer: any;
 
     beforeEach(() => {
         chromeSessionMock = {
@@ -61,16 +62,24 @@ describe('NativeScriptDebugAdapter', () => {
             setTransformOptions: () => ({}),
         };
 
-        nativeScriptDebugAdapter = new NativeScriptDebugAdapter(
-            { chromeConnection: mockConstructor(chromeConnectionMock), pathTransformer: mockConstructor(pathTransformerMock) },
+        sourceMapTransformer = {
+            clearTargetContext: () => undefined,
+            setDebugAdapter: () => undefined,
+        };
+
+        nativeScriptDebugAdapter = new NativeScriptDebugAdapter({
+            chromeConnection: mockConstructor(chromeConnectionMock),
+            pathTransformer: mockConstructor(pathTransformerMock),
+            sourceMapTransformer: mockConstructor(sourceMapTransformer),
+        },
             chromeSessionMock,
         );
 
         ChromeDebugAdapter.prototype.attach = () => Promise.resolve();
     });
 
-    const platforms = [ 'android', 'ios' ];
-    const launchMethods = [ 'launch', 'attach' ];
+    const platforms = ['android', 'ios'];
+    const launchMethods = ['launch', 'attach'];
 
     platforms.forEach((platform) => {
         launchMethods.forEach((method) => {


### PR DESCRIPTION
Add support for Debug + HMR - currently it is not working, as when a hot-module is applied, VSCode does not know that the current hot-module is mapped to the actual changed file (main-view-model) for example.
To fix this, add SourceMapTransformer and plug in the scriptParsed method. When breakpoint is set, cache it (in nativeScriptDebugAdapter), so once hot-module is applied, set the breakpoints from its original file (i.e. main-view-model) in the newly applied hot module.
This is exactly how Chrome works.

Also, add logic in pathTransformer to map files from `platforms` dir when debugging on iOS.

Related to: https://github.com/NativeScript/nativescript-vscode-extension/issues/221