### PR TITLE
fix: return empty path for the evaluated scripts

### DIFF
--- a/src/debug-adapter/nativeScriptPathTransformer.ts
+++ b/src/debug-adapter/nativeScriptPathTransformer.ts
@@ -46,10 +46,12 @@ export class NativeScriptPathTransformer extends UrlPathTransformer {
             relativePath = this.isAndroid ? matches[3] : matches[2];
         }
 
-        return this.getFileFromAppDir(relativePath) ||
+        const result = this.getFileFromAppDir(relativePath) ||
             this.getFileFromNodeModulesDir(relativePath) ||
             this.getFileFromPlatformsDir(relativePath) ||
-            scriptUrl;
+            await super.targetUrlToClientPath(scriptUrl);
+
+        return result;
     }
 
     private getFileFromAppDir(rawDevicePath: string): string {

--- a/src/tests/pathTransformData.ts
+++ b/src/tests/pathTransformData.ts
@@ -7,22 +7,22 @@ const tests = [
         scriptUrl: 'file:///data/data/org.nativescript.TabNavigation/files/app/main.js',
     },
     {
-        expectedResult: 'VM1',
+        expectedResult: '',
         platform: 'android',
         scriptUrl: 'VM1',
     },
     {
-        expectedResult: 'native prologue.js',
+        expectedResult: '',
         platform: 'android',
         scriptUrl: 'native prologue.js',
     },
     {
-        expectedResult: 'v8/gc',
+        expectedResult: '',
         platform: 'android',
         scriptUrl: 'v8/gc',
     },
     {
-        expectedResult: 'VM25',
+        expectedResult: '',
         platform: 'android',
         scriptUrl: 'VM25',
     },
@@ -81,7 +81,7 @@ const tests = [
         scriptUrl: 'file:///data/data/org.nativescript.TabNavigation/files/app/tns_modules/tns-core-modules/ui/layouts/layout-base.js',
     },
     {
-        expectedResult: 'ng:///css/0/data/data/org.nativescript.TabNavigation/files/app/tabs/tabs.component.scss.ngstyle.js',
+        expectedResult: '',
         platform: 'android',
         scriptUrl: 'ng:///css/0/data/data/org.nativescript.TabNavigation/files/app/tabs/tabs.component.scss.ngstyle.js',
     },


### PR DESCRIPTION
Fallback to the default path transform implementation if we are not able to find a local file instead of returning the device path. If we return `VM<ScriptID>` (e.g. "VM12") for the eval scripts, a "Could not load source 'undefined': Could not retrieve content.. " exception is thrown.

Related to: https://github.com/NativeScript/nativescript-vscode-extension/issues/237 https://github.com/NativeScript/nativescript-vscode-extension/issues/251
