### PR TITLE
fix: debugging apps with library set should work on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.10.2
+====
+## Bug Fixes
+ - [Unable to debug applications when output.library in webpack.config.js is set](https://github.com/NativeScript/nativescript-vscode-extension/issues/263)
+
+
 0.10.1
 ====
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "minNativescriptCliVersion": "2.5.0",
   "icon": "images/icon.png",
   "displayName": "NativeScript",

--- a/src/debug-adapter/nativeScriptDebugAdapter.ts
+++ b/src/debug-adapter/nativeScriptDebugAdapter.ts
@@ -186,7 +186,7 @@ export class NativeScriptDebugAdapter extends ChromeDebugAdapter {
             args.sourceMapPathOverrides['webpack:///*'] = `${fullAppDirPath}/*`;
         }
 
-        const webpackConfigFile = join(`./${args.webRoot}`, 'webpack.config.js');
+        const webpackConfigFile = join(args.webRoot, 'webpack.config.js');
 
         if (existsSync(webpackConfigFile)) {
             try {


### PR DESCRIPTION
Currently when you set library in your webpack.config.js, you are able to debug your app on windows, but not on macOS and Linux. The problem is in the way `path.join` works for UNIX style paths. The current code appends `./` in the beginning of the path, which is normally a full path:
```
path.join(`.//Users/vladimirov/Work/nativescript-cli-2/scratch/app1`, "test1.js")
'Users/vladimirov/Work/nativescript-cli-2/scratch/app1/test1.js'
```

As you can see, this removes the starting `/` from the full path, so the VSCode extension is unabel to get correct path to the searched file (webpack.config.js in our case).
On windows the result is:
```
> path.join("./D:\\Work\\nativescript-cli\\scratch\\app1", "test1.js")
'D:\\Work\\nativescript-cli\\scratch\\app1\\test1.js'
```
