### PR TITLE
Bug fix vscode debugger when using Angular based NativeScript projects.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "https://github.com/NativeScript/nativescript-vscode-extension/"
   },
-  "publisher": "Telerik",
+  "publisher": "NativeScript",
   "bugs": "https://github.com/NativeScript/nativescript-vscode-extension/issues",
   "engines": {
     "vscode": "^1.19.0"

--- a/src/debug-adapter/nativeScriptDebugAdapter.ts
+++ b/src/debug-adapter/nativeScriptDebugAdapter.ts
@@ -166,6 +166,22 @@ export class NativeScriptDebugAdapter extends ChromeDebugAdapter {
         }
     }
 
+    /**
+     * Determines if the NativeScript project being debugged is an Angular based
+     * project by returning true if an **angular.json** file exists at the base
+     * of the project or returns false if not found.
+     * @param webRoot The root of the project.
+     */
+    private isAngularProject(webRoot): boolean {
+        const isAngularProject = existsSync(join(webRoot, 'angular.json'));
+
+        if (isAngularProject) {
+            logger.log('Angular project detected, found angular.json file.');
+        }
+
+        return isAngularProject;
+    }
+
     private translateArgs(args): any {
         if (args.diagnosticLogging) {
             args.trace = args.diagnosticLogging;
@@ -179,7 +195,7 @@ export class NativeScriptDebugAdapter extends ChromeDebugAdapter {
             args.sourceMapPathOverrides = {};
         }
 
-        const appDirPath = this.getAppDirPath(args.webRoot) || 'app';
+        const appDirPath = this.getAppDirPath(args.webRoot) || (this.isAngularProject(args.webRoot) ? 'src' : 'app');
         const fullAppDirPath = join(args.webRoot, appDirPath);
 
         if (!args.sourceMapPathOverrides['webpack:///*']) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     services.logger = new ChannelLogger(channel);
 
-    const packageJSON = vscode.extensions.getExtension('Telerik.nativescript').packageJSON;
+    const packageJSON = vscode.extensions.getExtension('nativescript.nativescript').packageJSON;
     const cliVersion = services.cli().executeGetVersion();
 
     if (!cliVersion) {

--- a/src/tests/nativeScriptDebugAdapter.tests.ts
+++ b/src/tests/nativeScriptDebugAdapter.tests.ts
@@ -141,8 +141,12 @@ describe('NativeScriptDebugAdapter', () => {
             it(`${method} for ${platform} should add sourceMapPathOverrides data`, async () => {
                 const spy = sinon.spy(ChromeDebugAdapter.prototype, 'attach');
                 const existsSyncStub = sinon.stub(fs, 'existsSync');
+                // Need to also stub isAngularProject to return false or it will always return true bc it utilizes
+                // `fs.existsSync` which is also stubbed and made to return true in this test.
+                const isAngularProjectStub = sinon.stub(nativeScriptDebugAdapter, 'isAngularProject');
 
                 existsSyncStub.returns(true);
+                isAngularProjectStub.returns(false);
                 webpackConfigFunctionStub
                     .withArgs({ [platform]: platform })
                     .returns({ output: { library: 'myLib' } });
@@ -164,8 +168,12 @@ describe('NativeScriptDebugAdapter', () => {
             it(`${method} for ${platform} should not fail when unable to require webpack.config.js`, async () => {
                 const spy = sinon.spy(ChromeDebugAdapter.prototype, 'attach');
                 const existsSyncStub = sinon.stub(fs, 'existsSync');
+                // Need to also stub isAngularProject to return false or it will always return true bc it utilizes
+                // `fs.existsSync` which is also stubbed and made to return true in this test.
+                const isAngularProjectStub = sinon.stub(nativeScriptDebugAdapter, 'isAngularProject');
 
                 existsSyncStub.returns(true);
+                isAngularProjectStub.returns(false);
                 webpackConfigFunctionStub
                     .withArgs({ [platform]: platform })
                     .throws(new Error('test'));


### PR DESCRIPTION
I believe this addresses #278 and [#8930](https://github.com/NativeScript/NativeScript/issues/8930). I have never been able to properly debug an Angular based NativeScript project in vscode using this "nativescript-vscode-extension" because vscode always says `"Breakpoint ignored because generated code not found (source map problem?)"`.  Regular plain JavaScript projects work as expected but not with Angular.  After combing through the debug console and logging output from the extension, I found the problem to be that the path of the source files have `app/app` in it when it should be `src/app`.  For example, with a fresh NativeScript Angular HelloWorld project `ns create ns-angular-project --ng` the vscode debugger says the path is:
`e:/my-projects/ns-angular-project/app/app/item/item-detail.component.ts` when it should be:
`e:/my-projects/ns-angular-project/src/app/item/item-detail.component.ts`

So what I did in this PR is added a check for an **"angular.json"** file in the base of the project in order to determine if it is an Angular based project or not.  If it is, then the `appDirPath` is changed to `src` from `app`. For other projects the behavior will remain the same, leaving it as "app" because plain JavaScript projects were working fine already.

All tests are passing. I also tried it out on both brand new NativeScript Angular projects and NativeScript plain JavaScript projects, and they both work great now!

I also added a second unrelated commit that fixes the extension publisher to `NativeScript` from `Telerik` and the extension name from `Telerik.nativescript` to `nativescript.nativescript` so that it matches what is currently in the vscode extension marketplace so it won't look like a different extension when you install it.

Please let me know if you have any questions!